### PR TITLE
Encapsulate every canvas2D related attributes into textureDrawer

### DIFF
--- a/src/colorHistogramGui.cpp
+++ b/src/colorHistogramGui.cpp
@@ -1,8 +1,8 @@
 #include "colorHistogramGui.h"
 
 //ColorHistogramGui::ColorHistogramGui(Renderer* renderer) : ptrRenderer(renderer)
-ColorHistogramGui::ColorHistogramGui(ColorHistogram& histogram) 
-	: colorHistogram(histogram)
+ColorHistogramGui::ColorHistogramGui(ColorHistogram& histogram, TextureDrawer& textureDrawer) 
+	: colorHistogram(histogram), textureDrawer(textureDrawer)
 {
 
 }
@@ -42,11 +42,14 @@ bool ColorHistogramGui::getHistogramShown()
 	return (histogramShown);
 }
 
-void ColorHistogramGui::update(ofPixels& p_pixels)
+void ColorHistogramGui::update()
 {
-	colorHistogram.showHistogram(p_pixels, histogramBinSizeSlider);
-	updateOnceBool = false;
-	
+	if (getUpdateHistogram())
+	{
+		ofPixels pixels = textureDrawer.grabCanvasScreen().getPixels();
+		colorHistogram.showHistogram(pixels, histogramBinSizeSlider);
+		updateOnceBool = false;
+	}
 }
 
 bool ColorHistogramGui::getAutomaticUpdate()
@@ -61,11 +64,11 @@ void ColorHistogramGui::updateOnce()
 
 void ColorHistogramGui::draw()
 {
-	histogramPanel.draw();
 	if (histogramShown)
 	{
-		//colorHistogram.draw();
+		colorHistogram.draw();
 	}
+	histogramPanel.draw();
 }
 
 void ColorHistogramGui::toggleAutomaticHistogramUpdate()

--- a/src/colorHistogramGui.h
+++ b/src/colorHistogramGui.h
@@ -2,15 +2,16 @@
 
 #include "ofxGui.h"
 #include "colorHistogram.h"
+#include "textureDrawer.h"
 
 class ColorHistogramGui
 {
 public:
 
-	ColorHistogramGui(ColorHistogram& histogram);
+	ColorHistogramGui(ColorHistogram& histogram, TextureDrawer& textureDrawer);
 
 	void setup(int positionXInitiale, int positionYInitiale);
-	void update(ofPixels& p_pixels);
+	void update();
 	void updateOnce();
 	void draw();
 
@@ -20,6 +21,8 @@ public:
 
 private:
 	ColorHistogram& colorHistogram;
+	TextureDrawer& textureDrawer;
+
 	ofParameter<string> histogramCurrentStatus;
 	ofxPanel histogramPanel;
 	ofxButton histogramUpdate;

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -2,6 +2,11 @@
 
 void Cursor::setup(int drawingCanvasX, int drawingCanvasY, int drawingCanvasSize)
 {
+	ofAddListener(ofEvents().mouseMoved, this, &Cursor::mouseMoved);
+	ofAddListener(ofEvents().mouseDragged, this, &Cursor::mouseMoved);
+	//ofAddListener(ofEvents().mousePressed, this, &Cursor::mouseMoved);
+	//ofAddListener(ofEvents().mouseReleased, this, &Cursor::mouseMoved);
+
 	this->drawingCanvasX = drawingCanvasX;
 	this->drawingCanvasY = drawingCanvasY;
 	this->drawingCanvasSize = drawingCanvasSize;
@@ -50,9 +55,8 @@ bool Cursor::isCursorInDrawingCanvas()
 		y >= drawingCanvasY && y <= (drawingCanvasY + drawingCanvasSize);
 }
 
-
-void Cursor::setPosition(int x, int y)
+void Cursor::mouseMoved(ofMouseEventArgs & mouse)
 {
-	this->x = x;
-	this->y = y;
+	x = mouse.x;
+	y = mouse.y;
 }

--- a/src/cursor.cpp
+++ b/src/cursor.cpp
@@ -1,15 +1,17 @@
 #include "cursor.h"
 
-void Cursor::setup(int drawingCanvasX, int drawingCanvasY, int drawingCanvasSize)
+Cursor::Cursor(TextureDrawer & textureDrawer):
+	textureDrawer(textureDrawer)
+{
+}
+
+void Cursor::setup()
 {
 	ofAddListener(ofEvents().mouseMoved, this, &Cursor::mouseMoved);
 	ofAddListener(ofEvents().mouseDragged, this, &Cursor::mouseMoved);
 	//ofAddListener(ofEvents().mousePressed, this, &Cursor::mouseMoved);
 	//ofAddListener(ofEvents().mouseReleased, this, &Cursor::mouseMoved);
 
-	this->drawingCanvasX = drawingCanvasX;
-	this->drawingCanvasY = drawingCanvasY;
-	this->drawingCanvasSize = drawingCanvasSize;
 	pencilImage.load("cursor/pencil.png");
 	handImage.load("cursor/hand.png");
 }
@@ -41,18 +43,12 @@ void Cursor::draw()
 
 void Cursor::update()
 {
-	if (isCursorInDrawingCanvas()) {
+	if (textureDrawer.isMouseInsideCanvas(x, y)) {
 		setCursorImage(pencil);
 	}
 	else {
 		setCursorImage(none);
 	}
-}
-
-bool Cursor::isCursorInDrawingCanvas()
-{
-	return x >= drawingCanvasX && x <= (drawingCanvasX + drawingCanvasSize) &&
-		y >= drawingCanvasY && y <= (drawingCanvasY + drawingCanvasSize);
 }
 
 void Cursor::mouseMoved(ofMouseEventArgs & mouse)

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -15,11 +15,12 @@ public:
 	void setCursorImage(CursorTypes type);
 	void draw();
 	void update();
-	void setPosition(int x, int y);
 
 private:
 	int x;
 	int y;
+
+	void mouseMoved(ofMouseEventArgs & mouse);
 
 	int drawingCanvasSize;
 	int drawingCanvasX;

--- a/src/cursor.h
+++ b/src/cursor.h
@@ -1,17 +1,20 @@
 #pragma once
 #include "ofMain.h"
+#include "textureDrawer.h"
 
 enum CursorTypes
 {
+	none,
 	pencil,
-	hand,
-	none
+	hand
 };
 
 class Cursor
 {
 public:
-	void setup(int drawingCanvasX, int drawingCanvasY, int drawingCanvasSize);
+	Cursor(TextureDrawer& textureDrawer);
+
+	void setup();
 	void setCursorImage(CursorTypes type);
 	void draw();
 	void update();
@@ -22,14 +25,10 @@ private:
 
 	void mouseMoved(ofMouseEventArgs & mouse);
 
-	int drawingCanvasSize;
-	int drawingCanvasX;
-	int drawingCanvasY;
-
 	ofImage pencilImage;
 	ofImage handImage;
 	CursorTypes type;
 
-	bool isCursorInDrawingCanvas();
+	TextureDrawer& textureDrawer;
 };
 

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -46,12 +46,10 @@ void ofApp::mouseDragged(int x, int y, int button){
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	renderer.mousePressed(x, y);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	renderer.mouseReleased(x, y);
 }
 
 //--------------------------------------------------------------

--- a/src/ofApp.cpp
+++ b/src/ofApp.cpp
@@ -38,23 +38,19 @@ void ofApp::keyReleased(int key){
 
 //--------------------------------------------------------------
 void ofApp::mouseMoved(int x, int y ){
-	renderer.cursor.setPosition(x, y);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseDragged(int x, int y, int button){
-	renderer.cursor.setPosition(x, y);
 }
 
 //--------------------------------------------------------------
 void ofApp::mousePressed(int x, int y, int button){
-	renderer.cursor.setPosition(x, y);
 	renderer.mousePressed(x, y);
 }
 
 //--------------------------------------------------------------
 void ofApp::mouseReleased(int x, int y, int button){
-	renderer.cursor.setPosition(x, y);
 	renderer.mouseReleased(x, y);
 }
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -2,11 +2,14 @@
 
 void Renderer::setup()
 {
+	glm::vec2 initialCanvas2dPosition(225, ofGetHeight() / 3.5);
+	int initialCanvas2dSize = 600;
+
 	cursor.setup();
 
-	textureDrawer.setup(drawingCanvasX, drawingCanvasY, drawingCanvasSize);
+	textureDrawer.setup(initialCanvas2dPosition.x, initialCanvas2dPosition.y, initialCanvas2dSize);
 	fileManagerGui.setup();
-	canvas2dGui.setup(drawingCanvasY);
+	canvas2dGui.setup(initialCanvas2dPosition.y);
 	
 	//Il faudra ajuster la position de départ exacte plus tard
 	colorHistogram.setup();
@@ -19,17 +22,7 @@ void Renderer::update()
 	canvas2dGui.update();
 	textureDrawer.update();
 	cursor.update();
-
-	//À implémenter plus tard: Faire l'update automatique seulement lorsqu'il y a un changement, ou une fois à toutes les x frames
-	if (colorHistogramGui.getUpdateHistogram())
-	{
-		//Vérifier les dimensions...
-		image.grabScreen(drawingCanvasX, drawingCanvasY, drawingCanvasSize, drawingCanvasSize);
-		ofPixels pixels = image.getPixels();
-		colorHistogramGui.update(pixels);
-		//colorHistogram.update();
-	}
-	
+	colorHistogramGui.update();	
 }
 
 void Renderer::draw()
@@ -39,11 +32,6 @@ void Renderer::draw()
 	cursor.draw();
 	fileManagerGui.draw();
 	canvas2dGui.draw();
-	
-	if (colorHistogramGui.getHistogramShown())
-	{
-		colorHistogram.draw();
-	}
 	colorHistogramGui.draw();
 }
 

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -6,12 +6,6 @@ void Renderer::setup()
 	cursor.setCursorImage(none);
 
 	textureDrawer.setup(drawingCanvasX, drawingCanvasY, drawingCanvasSize);
-	fboTexture.allocate(drawingCanvasSize, drawingCanvasSize, GL_RGBA);
-	fboTexture.begin();
-	ofClear(255, 255);
-	ofSetColor(255);
-	fboTexture.end();
-
 	fileManagerGui.setup();
 	canvas2dGui.setup(drawingCanvasY);
 	
@@ -42,17 +36,6 @@ void Renderer::update()
 void Renderer::draw()
 {
 	ofSetBackgroundColor(canvas2dGui.backGroundColor);
-
-	ofSetColor(255);
-	fboTexture.draw(drawingCanvasX, drawingCanvasY);
-	/*ofBackgroundGradient(ofColor::white, ofColor::gray);
-	ofSetColor(255, 130, 0);
-	ofDrawCircle(ofGetWidth() / 2, ofGetHeight() / 2, 50);*/
-
-	/*if (image.isAllocated()) {
-		ofSetColor(255);
-		image.draw(0, 0, ofGetWidth(), ofGetHeight());
-	}*/
 	textureDrawer.draw();
 	cursor.draw();
 	fileManagerGui.draw();

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -34,19 +34,3 @@ void Renderer::draw()
 	canvas2dGui.draw();
 	colorHistogramGui.draw();
 }
-
-void Renderer::mousePressed(int x, int y)
-{
-	textureDrawer.mouse_pressed_posX = x;
-	textureDrawer.mouse_pressed_posY = y;
-	textureDrawer.selectShape(x, y);
-}
-
-void Renderer::mouseReleased(int x, int y)
-{
-	textureDrawer.mouse_current_posX = x;
-	textureDrawer.mouse_current_posY = y;
-	textureDrawer.add_vector_shape();
-}
-
-

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -2,8 +2,7 @@
 
 void Renderer::setup()
 {
-	cursor.setup(drawingCanvasX, drawingCanvasY, drawingCanvasSize);
-	cursor.setCursorImage(none);
+	cursor.setup();
 
 	textureDrawer.setup(drawingCanvasX, drawingCanvasY, drawingCanvasSize);
 	fileManagerGui.setup();

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -18,12 +18,7 @@ public:
 
 	const int drawingCanvasSize = 600;
 	int drawingCanvasX = 225;
-	int drawingCanvasY = ofGetHeight() / 3.5;
-
-	ofFbo fboTexture;
-
-	int mousePosX;
-	int mousePosY;	
+	int drawingCanvasY = ofGetHeight() / 3.5;	
 
 	void mousePressed(int x, int y);
 	void mouseReleased(int x, int y);

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -23,14 +23,14 @@ public:
 	ofFbo fboTexture;
 
 	int mousePosX;
-	int mousePosY;
-	Cursor cursor;
-	
+	int mousePosY;	
 
 	void mousePressed(int x, int y);
 	void mouseReleased(int x, int y);
 
 private:
+	Cursor cursor;
+
 	ofImage image;
 
 	FileManagerGui fileManagerGui;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -16,9 +16,6 @@ public:
 	void update();
 	void draw();
 
-	void mousePressed(int x, int y);
-	void mouseReleased(int x, int y);
-
 private:
 
 	ofImage image;

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -16,10 +16,6 @@ public:
 	void update();
 	void draw();
 
-	const int drawingCanvasSize = 600;
-	int drawingCanvasX = 225;
-	int drawingCanvasY = ofGetHeight() / 3.5;	
-
 	void mousePressed(int x, int y);
 	void mouseReleased(int x, int y);
 
@@ -33,7 +29,7 @@ private:
 	CanvasGui canvas2dGui = CanvasGui(textureDrawer);
 
 	ColorHistogram colorHistogram;
-	ColorHistogramGui colorHistogramGui = ColorHistogramGui(colorHistogram);
+	ColorHistogramGui colorHistogramGui = ColorHistogramGui(colorHistogram, textureDrawer);
 
 	Cursor cursor = Cursor(textureDrawer);
 };

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -24,7 +24,6 @@ public:
 	void mouseReleased(int x, int y);
 
 private:
-	Cursor cursor;
 
 	ofImage image;
 
@@ -35,4 +34,6 @@ private:
 
 	ColorHistogram colorHistogram;
 	ColorHistogramGui colorHistogramGui = ColorHistogramGui(colorHistogram);
+
+	Cursor cursor = Cursor(textureDrawer);
 };

--- a/src/textureDrawer.cpp
+++ b/src/textureDrawer.cpp
@@ -2,6 +2,9 @@
 
 void TextureDrawer::setup(int drawingCanvasX, int drawingCanvasY, int drawingCanvasSize)
 {
+	ofAddListener(ofEvents().mousePressed, this, &TextureDrawer::mousePressed);
+	ofAddListener(ofEvents().mouseReleased, this, &TextureDrawer::mouseReleased);
+
 	this->drawingCanvasX = drawingCanvasX;
 	this->drawingCanvasY = drawingCanvasY;
 	this->drawingCanvasSize = drawingCanvasSize;
@@ -522,4 +525,18 @@ void TextureDrawer::deleteSelectedShapes()
 			shapes[i].type = VectorPrimitiveType::none;
 		}
 	}
+}
+
+void TextureDrawer::mousePressed(ofMouseEventArgs & mouse)
+{
+	mouse_pressed_posX = mouse.x;
+	mouse_pressed_posY = mouse.y;
+	selectShape(mouse.x, mouse.y);
+}
+
+void TextureDrawer::mouseReleased(ofMouseEventArgs & mouse)
+{
+	mouse_current_posX = mouse.x;
+	mouse_current_posY = mouse.y;
+	add_vector_shape();
 }

--- a/src/textureDrawer.cpp
+++ b/src/textureDrawer.cpp
@@ -473,6 +473,12 @@ void TextureDrawer::drawSelectionRectangles()
 	}
 }
 
+bool TextureDrawer::isMouseInsideCanvas(int x, int y)
+{
+	return x >= drawingCanvasX && x <= (drawingCanvasX + drawingCanvasSize) &&
+		y >= drawingCanvasY && y <= (drawingCanvasY + drawingCanvasSize);
+}
+
 bool TextureDrawer::isMouseOutsideCanvas()
 {
 	int maxValidX = drawingCanvasX + drawingCanvasSize;

--- a/src/textureDrawer.cpp
+++ b/src/textureDrawer.cpp
@@ -22,6 +22,10 @@ void TextureDrawer::setup(int drawingCanvasX, int drawingCanvasY, int drawingCan
 
 void TextureDrawer::draw()
 {
+	ofFill();
+	ofSetColor(255);
+	ofDrawRectangle(drawingCanvasX, drawingCanvasY, drawingCanvasSize, drawingCanvasSize);
+
 	for (int index = 0; index < count; index++)
 	{
 		switch (shapes[index].type)

--- a/src/textureDrawer.cpp
+++ b/src/textureDrawer.cpp
@@ -508,6 +508,13 @@ void TextureDrawer::resetSelection()
 	}
 }
 
+ofImage TextureDrawer::grabCanvasScreen()
+{
+	ofImage image;
+	image.grabScreen(drawingCanvasX, drawingCanvasY, drawingCanvasSize, drawingCanvasSize);
+	return image;
+}
+
 void TextureDrawer::deleteSelectedShapes()
 {
 	for (int i = 0; i < head; ++i) {

--- a/src/textureDrawer.h
+++ b/src/textureDrawer.h
@@ -52,6 +52,8 @@ public:
 
 	void resetSelection();
 
+	ofImage grabCanvasScreen();
+
 private:
 	int count;
 	int head;

--- a/src/textureDrawer.h
+++ b/src/textureDrawer.h
@@ -92,5 +92,8 @@ private:
 
 	bool isMouseOutsideCanvas();
 	bool isShapeOutsideCanvas(int x1, int x2, int y1, int y2);
+
+	void mousePressed(ofMouseEventArgs & mouse);
+	void mouseReleased(ofMouseEventArgs & mouse);
 };
 

--- a/src/textureDrawer.h
+++ b/src/textureDrawer.h
@@ -31,6 +31,8 @@ public:
 	int mouse_current_posX;
 	int mouse_current_posY;
 
+	bool isMouseInsideCanvas(int x, int y);
+
 	void selectPointType();
 	void selectLineType();
 	void selectRectangleType();


### PR DESCRIPTION
On devrait garder une seule "source of truth" pour les attributs d'un objet en particulier.