### PR TITLE
Refactor/boite delimitation

### DIFF
--- a/src/canvas3dGui.cpp
+++ b/src/canvas3dGui.cpp
@@ -12,7 +12,7 @@ void Canvas3DGui::setup(int canvasPositionX, int canvasPositionY, int canvasSize
 	shaderType.setup("Type choisi de shader");
 	selectionType.setup("Type de modele choisi");
 
-	optionsPanel.add(boiteDelimButton.setup("Boite delimitation"));
+	optionsPanel.add(boiteDelimitationToggle.set("Boite delimitation",false));
 	optionsPanel.add(importModelButton.setup("import model"));
 
 	selectedPrimitiveType.setName("Primitive:");
@@ -42,7 +42,7 @@ void Canvas3DGui::setup(int canvasPositionX, int canvasPositionY, int canvasSize
 	noShaderSelectedButton.addListener(this, &Canvas3DGui::noShaderSelected);
 	lambertShaderSelectedButton.addListener(this, &Canvas3DGui::lambertShaderSelected);
 
-	boiteDelimButton.addListener(this, &Canvas3DGui::boiteDelimButtonClicked);
+//	boiteDelimitationToggle.addListener(this, &Canvas3DGui::boiteDelimButtonClicked);
 	importModelButton.addListener(this, &Canvas3DGui::importModelClicked);
 
 	selectModelTypeButton.addListener(this, &Canvas3DGui::selectModelType);
@@ -56,6 +56,7 @@ void Canvas3DGui::update()
 {
 	textureDrawer3D.updateModelParameters(modelColorPicker, modelScale);
 	textureDrawer3D.updateAnimationParameters(rotationSpeed, waveIntensity, rotationAnimationToggle, levitationAnimationToggle);
+	textureDrawer3D.updateDelimitationBox(boiteDelimitationToggle);
 }
 
 void Canvas3DGui::draw()
@@ -63,10 +64,11 @@ void Canvas3DGui::draw()
 	optionsPanel.draw();
 }
 
-void Canvas3DGui::boiteDelimButtonClicked()
-{
-	std::cout << "BoiteDelimButtonCLicked" << std::endl;
-}
+//void Canvas3DGui::boiteDelimButtonClicked()
+//{
+//
+//	std::cout << "BoiteDelimButtonCLicked" << std::endl;
+//}
 
 void Canvas3DGui::importModelClicked()
 {

--- a/src/canvas3dGui.h
+++ b/src/canvas3dGui.h
@@ -16,7 +16,7 @@ public:
 
 private:
 	ofxPanel optionsPanel;
-	ofxButton boiteDelimButton;
+	ofParameter<bool> boiteDelimitationToggle;
 	ofxButton importModelButton;
 
 	ofxButton selectModelTypeButton;
@@ -46,7 +46,7 @@ private:
 	ofxButton lambertShaderSelectedButton;
 	ofxButton noShaderSelectedButton;
 
-	void boiteDelimButtonClicked();
+	//void boiteDelimButtonClicked();
 	void importModelClicked();
 
 	void lambertShaderSelected();

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -203,9 +203,13 @@ ofVec3f TextureDrawer3D::getMeshBoundingBoxDimension(const ofMesh &mesh) {
 		[](const ofPoint& lhs, const ofPoint& rhs) {
 		return lhs.z < rhs.z;
 	});
-	return ofVec3f(xExtremes.second->x - xExtremes.first->x,
-		yExtremes.second->y - yExtremes.first->y,
-		zExtremes.second->z - zExtremes.first->z);
+
+	double scaling = model.getNormalizedScale();
+	//model.calculateDimensions();
+	ofVec3f dim = ofVec3f((xExtremes.second->x - xExtremes.first->x) * scaling,
+						(yExtremes.second->y - yExtremes.first->y) * scaling,
+						(zExtremes.second->z - zExtremes.first->z) * scaling);
+	return dim;
 }
 
 

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -135,9 +135,6 @@ void TextureDrawer3D::draw()
 	//ofSetColor(255);
 	//ofDrawRectangle(modelCanvasX, modelCanvasY, modelCanvasSize, modelCanvasSize);
 
-	ofSetColor(255,0,0);
-	ofDrawCircle( centerX, centerY, 90, 10);
-
 	if (selectedShader == ShaderType::lambert) 
     {
 		cam.begin();
@@ -146,7 +143,7 @@ void TextureDrawer3D::draw()
 		light.enable();
 		shader.begin();
 		drawModel();
-		drawBoiteDelimitation(mesh);
+		drawBoiteDelimitation();
 		cam.end();
 		shader.end();
 
@@ -181,10 +178,8 @@ void TextureDrawer3D::draw()
 	//fboTexture3D.end();
 }
 
-void TextureDrawer3D::drawBoiteDelimitation(const ofMesh &mesh)
+void TextureDrawer3D::drawBoiteDelimitation()
 {
-	//ofVec3f boundingWigthHeightDepth = getMeshBoundingBoxDimension(mesh);
-	//glm::vec3 positionModel = glm::vec3(centerX, centerY - (boundingWigthHeightDepth.y/2), 90);
 	ofPoint sceneMax = model.getSceneMax();
 	ofPoint sceneMin = model.getSceneMin();
 	ofPoint sceneCenter = model.getSceneCenter();
@@ -196,9 +191,11 @@ void TextureDrawer3D::drawBoiteDelimitation(const ofMesh &mesh)
 	ofPoint tailleBoiteDelimitation = ofPoint((sceneMax.x - sceneMin.x) * scaling, (sceneMax.y - sceneMin.y) * scaling, (sceneMax.z - sceneMin.z) * scaling);
 	
 	ofPoint positionModel = model.getPosition();
-	ofPoint positionBox = ofPoint((sceneCenter.x * scaling) + positionModel.x, (sceneCenter.y * scaling) + positionModel.y, (sceneCenter.z * scaling)+ positionModel.z);
+	ofPoint positionBox = ofPoint(positionModel.x - (sceneCenter.x * scaling), positionModel.y - (sceneCenter.y * scaling), positionModel.z - (sceneCenter.z * scaling));
 	cout << scaling << "\n";
 	cout << positionModel.x << ", " << positionModel.y << ", " << positionModel.z << "\n";
+	cout << sceneCenter.x << ", " << sceneCenter.y << ", " << sceneCenter.z << "\n";
+	cout << positionBox.x << ", " << positionBox.y << ", " << positionBox.z << "\n";
 	cout << tailleBoiteDelimitation.x << ", " << tailleBoiteDelimitation.y << ", " << tailleBoiteDelimitation.z << "\n";
 	ofNoFill();
 	ofSetLineWidth(7);
@@ -207,28 +204,6 @@ void TextureDrawer3D::drawBoiteDelimitation(const ofMesh &mesh)
 
 }
 
-ofVec3f TextureDrawer3D::getMeshBoundingBoxDimension(const ofMesh &mesh) {
-
-	auto xExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
-		[](const ofPoint& lhs, const ofPoint& rhs) {
-		return lhs.x < rhs.x;
-	});
-	auto yExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
-		[](const ofPoint& lhs, const ofPoint& rhs) {
-		return lhs.y < rhs.y;
-	});
-	auto zExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
-		[](const ofPoint& lhs, const ofPoint& rhs) {
-		return lhs.z < rhs.z;
-	});
-	float scaling;
-	float scale = model.getScale().x;
-	scaling = model.getNormalizedScale()*scale;
-	ofVec3f dim = ofVec3f((xExtremes.second->x - xExtremes.first->x) * scaling,
-						(yExtremes.second->y - yExtremes.first->y) * scaling,
-						(zExtremes.second->z - zExtremes.first->z) * scaling);
-	return dim;
-}
 
 
 void TextureDrawer3D::applyLambertShader()
@@ -254,7 +229,7 @@ void TextureDrawer3D::drawModel()
 	{
 	case ModelType::model:
 		model.drawFaces();
-		drawBoiteDelimitation(mesh);
+		drawBoiteDelimitation();
 		break;
 	case ModelType::box:
 		if (selectedShader == ShaderType::none) {
@@ -292,6 +267,7 @@ void TextureDrawer3D::drawModel()
 			sphere.enableTextures();
 			sphere.draw(OF_MESH_FILL);
 			material.end();
+
 			float rayon = sphere.getRadius();
 			ofNoFill();
 			ofSetLineWidth(7);
@@ -301,6 +277,8 @@ void TextureDrawer3D::drawModel()
 		}
 		else {
 			sphere.drawFaces();
+
+
 			float rayon = sphere.getRadius();
 			ofNoFill();
 			ofSetLineWidth(7);
@@ -336,59 +314,6 @@ void TextureDrawer3D::resetCamera()
 	cam.setTarget(glm::vec3(centerX, centerY, 90));
 	cam.setupPerspective(true, 60, 0, 0, glm::vec2(-0.4, -0.1));
 	cam.setDistance(700);
-}
-
-void TextureDrawer3D::calculerBoiteDelimitation()
-{
-	std::vector<glm::vec3> vertices = mesh.getVertices();
-	std::vector<glm::vec3>::iterator it;
-
-	glm::vec3 pointGauche = vertices.at(0);
-	glm::vec3 pointAvant = vertices.at(0);
-	glm::vec3 pointDroit = vertices.at(0);
-	glm::vec3 pointArriere = vertices.at(0);
-	glm::vec3 pointDessus = vertices.at(0);
-	glm::vec3 pointDessous = vertices.at(0);
-
-	// Parcours du conteneur de vertices pour déterminer ceux qui
-	// Sont le plus aux extrémités
-	for (it = vertices.begin(); it != vertices.end(); ++it)
-	{
-		if ((*it).x < pointGauche.x)
-		{
-			pointGauche = *it;
-		}
-
-		if ((*it).x > pointDroit.x)
-		{
-			pointDroit = *it;
-		}
-
-		if ((*it).y < pointDessus.y)
-		{
-			pointDessus = *it;
-		}
-
-		if ((*it).y > pointDessous.y)
-		{
-			pointDessous = *it;
-		}
-
-		if ((*it).z < pointAvant.z)
-		{
-			pointAvant = *it;
-		}
-
-		if ((*it).z > pointArriere.z)
-		{
-			pointArriere = *it;
-		}
-	}
-
-	pointSupGaucheBoite = ofPoint(pointGauche.x, pointDessus.y, pointAvant.z);
-	largeurModel3D = pointDroit.x - pointGauche.x;
-	hauteurModel3D = pointDessus.y - pointDessous.y;
-	profondeurModel3D = pointArriere.z - pointAvant.z;
 }
 
 void TextureDrawer3D::selectSphereType()

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -14,7 +14,7 @@ void TextureDrawer3D::setup(int canvasPositionX, int canvasPositionY, int canvas
 
 	selectedShader = ShaderType::none;
 	//selectedType = ModelType::model;
-	selectedType = ModelType::box;
+	selectedType = ModelType::cone;
 
 	mesh = model.getMesh(0);
 	model.setPosition(centerX, centerY, 90);
@@ -179,16 +179,10 @@ void TextureDrawer3D::drawBoiteDelimitationModel()
 	
 	ofPoint positionModel = model.getPosition();
 	ofPoint positionBox = ofPoint(positionModel.x - (sceneCenter.x * scaling), positionModel.y - (sceneCenter.y * scaling), positionModel.z - (sceneCenter.z * scaling));
-	cout << scaling << "\n";
-	cout << positionModel.x << ", " << positionModel.y << ", " << positionModel.z << "\n";
-	cout << sceneCenter.x << ", " << sceneCenter.y << ", " << sceneCenter.z << "\n";
-	cout << positionBox.x << ", " << positionBox.y << ", " << positionBox.z << "\n";
-	cout << tailleBoiteDelimitation.x << ", " << tailleBoiteDelimitation.y << ", " << tailleBoiteDelimitation.z << "\n";
 	ofNoFill();
 	ofSetLineWidth(7);
 	ofSetColor(0, 255, 0);
 	ofDrawBox(positionBox.x, positionBox.y, positionBox.z, tailleBoiteDelimitation.x, tailleBoiteDelimitation.y, tailleBoiteDelimitation.z);
-
 }
 
 void TextureDrawer3D::applyLambertShader()
@@ -254,10 +248,26 @@ void TextureDrawer3D::drawModel()
 			cone.enableNormals();
 			cone.enableTextures();
 			cone.draw(OF_MESH_FILL);
-			material.end();
+			material.end();			
+			if (boiteDelimitation)
+			{
+				float sizeBase = cone.getRadius() * 2 * cone.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(cone.getPosition(), sizeBase, cone.getHeight() * cone.getGlobalScale().x, sizeBase);
+			}
 		}
 		else {
 			cone.drawFaces();
+			if (boiteDelimitation)
+			{
+				float sizeBase = cone.getRadius() * 2 * cone.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(cone.getPosition(), sizeBase, cone.getHeight() * cone.getGlobalScale().x, sizeBase);
+			}
 		}
 		
 		break;
@@ -302,9 +312,25 @@ void TextureDrawer3D::drawModel()
 			cylinder.enableTextures();
 			cylinder.draw(OF_MESH_FILL);
 			material.end();
+			if (boiteDelimitation)
+			{
+				float sizeBase = cylinder.getRadius() * 2 * cylinder.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(cylinder.getPosition(), sizeBase, cylinder.getHeight() * cylinder.getGlobalScale().x, sizeBase);
+			}
 		}
 		else {
 			cylinder.drawFaces();
+			if (boiteDelimitation)
+			{
+				float sizeBase = cylinder.getRadius() * 2 * cylinder.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(cylinder.getPosition(), sizeBase, cylinder.getHeight() * cylinder.getGlobalScale().x, sizeBase);
+			}
 		}
 		
 		break;

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -128,6 +128,14 @@ bool TextureDrawer3D::isMouseInsideModelCanvas(int x, int y)
 
 void TextureDrawer3D::draw()
 {	
+
+	ofFill();
+	ofSetColor(255);
+	ofDrawRectangle(modelCanvasX, modelCanvasY, modelCanvasSize, modelCanvasSize);
+
+	ofSetColor(255,0,0);
+	ofDrawCircle( centerX, centerY, 90, 10);
+
 	if (selectedShader == ShaderType::lambert) 
     {
 		cam.begin();
@@ -158,6 +166,10 @@ void TextureDrawer3D::draw()
 		ofDisableDepthTest();
 	}
 
+	ofPoint positionModel = ofPoint(centerX, centerY, 90);
+
+	drawBoiteDelimitation(mesh);
+
 	ofSetColor(255);
 	fboTexture3D.draw(modelCanvasX + modelCanvasSize + 10, modelCanvasY);
 	fboTexture3D.begin();
@@ -165,13 +177,37 @@ void TextureDrawer3D::draw()
 	fboTexture3D.end();
 }
 
-void TextureDrawer3D::drawBoiteDelimitation(ofPoint point, float width, float height, float depth)
+void TextureDrawer3D::drawBoiteDelimitation(const ofMesh &mesh)
 {
+	ofVec3f boundingWigthHeightDepth = getMeshBoundingBoxDimension(mesh);
+	glm::vec3 positionModel = glm::vec3(centerX, centerY, 90);
+	cout << positionModel.x << ", " << positionModel.y << ", " << positionModel.z << "\n";
+	cout << boundingWigthHeightDepth.x << ", " << boundingWigthHeightDepth.y << ", " << boundingWigthHeightDepth.z << "\n";
 	ofNoFill();
-	ofSetLineWidth(5);
-	ofSetColor(51);
-	ofDrawBox(point.x, point.y, point.z, width, height, depth);
+	ofSetLineWidth(7);
+	ofSetColor(0, 255, 0);
+	ofDrawBox(positionModel, boundingWigthHeightDepth.x, boundingWigthHeightDepth.y, boundingWigthHeightDepth.z);
 }
+
+ofVec3f TextureDrawer3D::getMeshBoundingBoxDimension(const ofMesh &mesh) {
+
+	auto xExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
+		[](const ofPoint& lhs, const ofPoint& rhs) {
+		return lhs.x < rhs.x;
+	});
+	auto yExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
+		[](const ofPoint& lhs, const ofPoint& rhs) {
+		return lhs.y < rhs.y;
+	});
+	auto zExtremes = minmax_element(mesh.getVertices().begin(), mesh.getVertices().end(),
+		[](const ofPoint& lhs, const ofPoint& rhs) {
+		return lhs.z < rhs.z;
+	});
+	return ofVec3f(xExtremes.second->x - xExtremes.first->x,
+		yExtremes.second->y - yExtremes.first->y,
+		zExtremes.second->z - zExtremes.first->z);
+}
+
 
 void TextureDrawer3D::applyLambertShader()
 {

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -45,7 +45,6 @@ void TextureDrawer3D::update()
 	cylinder.setScale(modelScale * 8);
 	box.setScale(modelScale * 8);
 	cone.setScale(modelScale * 17);
-	mesh = model.getCurrentAnimatedMesh(0);
 
 	if (useRotationAnimation) {
 		model.setRotation(0, ofGetFrameNum() * rotationSpeed, 0.0f, 1.0f, 0.0f);
@@ -135,11 +134,6 @@ bool TextureDrawer3D::isMouseInsideModelCanvas(int x, int y)
 
 void TextureDrawer3D::draw()
 {	
-
-	//ofFill();
-	//ofSetColor(255);
-	//ofDrawRectangle(modelCanvasX, modelCanvasY, modelCanvasSize, modelCanvasSize);
-
 	if (selectedShader == ShaderType::lambert) 
     {
 		cam.begin();

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -14,7 +14,7 @@ void TextureDrawer3D::setup(int canvasPositionX, int canvasPositionY, int canvas
 
 	selectedShader = ShaderType::none;
 	//selectedType = ModelType::model;
-	selectedType = ModelType::sphere;
+	selectedType = ModelType::box;
 
 	mesh = model.getMesh(0);
 	model.setPosition(centerX, centerY, 90);
@@ -191,8 +191,6 @@ void TextureDrawer3D::drawBoiteDelimitationModel()
 
 }
 
-
-
 void TextureDrawer3D::applyLambertShader()
 {
 	model.disableMaterials();
@@ -227,9 +225,25 @@ void TextureDrawer3D::drawModel()
 			box.enableTextures();
 			box.draw(OF_MESH_FILL);
 			material.end();
+			if (boiteDelimitation)
+			{
+				float size = box.getDepth() * box.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(box.getPosition(), size, size, size);
+			}
 		}
 		else {
 			box.drawFaces();
+			if (boiteDelimitation)
+			{
+				float size = box.getDepth() * box.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(box.getPosition(), size, size, size);
+			}
 		}
 		
 		break;

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -13,7 +13,8 @@ void TextureDrawer3D::setup(int canvasPositionX, int canvasPositionY, int canvas
 	model.loadModel("teapot.obj");
 
 	selectedShader = ShaderType::none;
-	selectedType = ModelType::model;
+	//selectedType = ModelType::model;
+	selectedType = ModelType::sphere;
 
 	mesh = model.getMesh(0);
 	model.setPosition(centerX, centerY, 90);
@@ -166,15 +167,13 @@ void TextureDrawer3D::draw()
 	}
 }
 
-void TextureDrawer3D::drawBoiteDelimitation()
+void TextureDrawer3D::drawBoiteDelimitationModel()
 {
 	ofPoint sceneMax = model.getSceneMax();
 	ofPoint sceneMin = model.getSceneMin();
 	ofPoint sceneCenter = model.getSceneCenter();
 
-	float scaling;
-	float scale = model.getScale().x;
-	scaling = model.getNormalizedScale()*scale;
+	float scaling = model.getNormalizedScale() * modelScale;
 
 	ofPoint tailleBoiteDelimitation = ofPoint((sceneMax.x - sceneMin.x) * scaling, (sceneMax.y - sceneMin.y) * scaling, (sceneMax.z - sceneMin.z) * scaling);
 	
@@ -218,7 +217,7 @@ void TextureDrawer3D::drawModel()
 	case ModelType::model:
 		model.drawFaces();
 		if(boiteDelimitation)
-			drawBoiteDelimitation();
+			drawBoiteDelimitationModel();
 		break;
 	case ModelType::box:
 		if (selectedShader == ShaderType::none) {
@@ -249,6 +248,7 @@ void TextureDrawer3D::drawModel()
 		
 		break;
 	case ModelType::sphere:
+
 		if (selectedShader == ShaderType::none) {
 			material.begin();
 			sphere.enableColors();
@@ -256,24 +256,27 @@ void TextureDrawer3D::drawModel()
 			sphere.enableTextures();
 			sphere.draw(OF_MESH_FILL);
 			material.end();
+			
+			if (boiteDelimitation)
+			{
+				float size = sphere.getRadius() * 2 * sphere.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(sphere.getPosition(), size, size, size);
+			}
 
-			float rayon = sphere.getRadius();
-			ofNoFill();
-			ofSetLineWidth(7);
-			ofSetColor(0, 255, 0);
-			ofDrawBox(sphere.getPosition(), rayon*2*5, rayon*2*5, rayon*2*5);
-			cout << rayon << "\n";
 		}
 		else {
 			sphere.drawFaces();
-
-
-			float rayon = sphere.getRadius();
-			ofNoFill();
-			ofSetLineWidth(7);
-			ofSetColor(0, 255, 0);
-			ofDrawBox(sphere.getPosition(), rayon * 2 * 5, rayon * 2 * 5, rayon * 2 * 5);
-			cout << rayon << "\n";
+			if (boiteDelimitation)
+			{
+				float size = sphere.getRadius() * 2 * sphere.getGlobalScale().x;
+				ofNoFill();
+				ofSetLineWidth(7);
+				ofSetColor(0, 255, 0);
+				ofDrawBox(sphere.getPosition(), size, size, size);
+			}
 		}
 		
 		break;
@@ -321,7 +324,6 @@ void TextureDrawer3D::selectConeType()
 {
 	selectedType = ModelType::cone;
 }
-
 void TextureDrawer3D::selectModelType()
 {
 	selectedType = ModelType::model;

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -13,8 +13,7 @@ void TextureDrawer3D::setup(int canvasPositionX, int canvasPositionY, int canvas
 	model.loadModel("teapot.obj");
 
 	selectedShader = ShaderType::none;
-	//selectedType = ModelType::model;
-	selectedType = ModelType::cone;
+	selectedType = ModelType::model;
 
 	mesh = model.getMesh(0);
 	model.setPosition(centerX, centerY, 90);

--- a/src/textureDrawer3D.cpp
+++ b/src/textureDrawer3D.cpp
@@ -105,6 +105,11 @@ void TextureDrawer3D::updateAnimationParameters(float rotationSpeed, float waveI
 	this->useLevitationAnimation = waveAnimation;
 }
 
+void TextureDrawer3D::updateDelimitationBox(bool boiteDelimitation)
+{
+	this->boiteDelimitation = boiteDelimitation;
+}
+
 void TextureDrawer3D::updateShaderSelection(ShaderType selected)
 {
 	switch (selected)
@@ -143,39 +148,22 @@ void TextureDrawer3D::draw()
 		light.enable();
 		shader.begin();
 		drawModel();
-		drawBoiteDelimitation();
 		cam.end();
 		shader.end();
-
 		light.disable();
 		ofDisableLighting();
 		ofDisableDepthTest();
 	}
 	else 
-  {
+	{
 		ofEnableDepthTest();
-
 		light.enable();
-
 		cam.begin();
 		drawModel();
-		
 		cam.end();
-
 		light.disable();
-
 		ofDisableDepthTest();
 	}
-
-	ofPoint positionModel = ofPoint(centerX, centerY, 90);
-
-	
-
-	//ofSetColor(255);
-	//fboTexture3D.draw(modelCanvasX + modelCanvasSize + 10, modelCanvasY);
-	//fboTexture3D.begin();
-
-	//fboTexture3D.end();
 }
 
 void TextureDrawer3D::drawBoiteDelimitation()
@@ -229,7 +217,8 @@ void TextureDrawer3D::drawModel()
 	{
 	case ModelType::model:
 		model.drawFaces();
-		drawBoiteDelimitation();
+		if(boiteDelimitation)
+			drawBoiteDelimitation();
 		break;
 	case ModelType::box:
 		if (selectedShader == ShaderType::none) {

--- a/src/textureDrawer3D.h
+++ b/src/textureDrawer3D.h
@@ -23,6 +23,8 @@ public:
 	void updateAnimationParameters(float rotationSpeed, float waveIntensity, bool rotationAnimation, bool waveAnimation);
 	void updateShaderSelection(ShaderType selected);
 
+	void updateDelimitationBox(bool boiteDelimitation);
+
 	bool isMouseInsideModelCanvas(int x, int y);
 
 	void selectSphereType();
@@ -49,6 +51,7 @@ private:
 	ofFbo fboTexture3D;
 
 	void drawBoiteDelimitation();
+	bool boiteDelimitation;
 
 	void applyLambertShader();
 	ShaderType selectedShader;

--- a/src/textureDrawer3D.h
+++ b/src/textureDrawer3D.h
@@ -31,7 +31,6 @@ public:
 	void selectConeType();
 	void selectModelType();
 
-	ofVec3f getMeshBoundingBoxDimension(const ofMesh &mesh);
 
 private:
 	int modelCanvasSize;
@@ -49,8 +48,7 @@ private:
 
 	ofFbo fboTexture3D;
 
-	void calculerBoiteDelimitation();
-	void drawBoiteDelimitation(const ofMesh &mesh);
+	void drawBoiteDelimitation();
 
 	void applyLambertShader();
 	ShaderType selectedShader;

--- a/src/textureDrawer3D.h
+++ b/src/textureDrawer3D.h
@@ -50,7 +50,7 @@ private:
 
 	ofFbo fboTexture3D;
 
-	void drawBoiteDelimitation();
+	void drawBoiteDelimitationModel();
 	bool boiteDelimitation;
 
 	void applyLambertShader();

--- a/src/textureDrawer3D.h
+++ b/src/textureDrawer3D.h
@@ -31,6 +31,8 @@ public:
 	void selectConeType();
 	void selectModelType();
 
+	ofVec3f getMeshBoundingBoxDimension(const ofMesh &mesh);
+
 private:
 	int modelCanvasSize;
 	int modelCanvasX;
@@ -48,7 +50,7 @@ private:
 	ofFbo fboTexture3D;
 
 	void calculerBoiteDelimitation();
-	void drawBoiteDelimitation(ofPoint point, float width, float height, float depth);
+	void drawBoiteDelimitation(const ofMesh &mesh);
 
 	void applyLambertShader();
 	ShaderType selectedShader;


### PR DESCRIPTION
Boite de delimitation fonctionnelle sur toutes les primitives (box, cone, sphere, cylindre et un model)
Le toggle est fonctionnel, la boîte suit pour l'animation de levitation, et pour le changement de scaling.
Par contre elle ne tourne pas lors de l'animation de rotation.